### PR TITLE
templates, base: use SITENAME, not AUTHOR for the SITEURL link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -44,7 +44,7 @@
         <img src="{{ SITEURL }}/theme/images/logo.png" alt="logo">
         {% endif %}
       </a>
-      <h2><a href="{{ SITEURL }}">{{ AUTHOR }}</a></h2>
+      <h2><a href="{{ SITEURL }}">{{ SITENAME }}</a></h2>
       <p>{{ TAGLINE }}</p>
       <ul>
         {% for title, link in MENUITEMS %}


### PR DESCRIPTION
To be consistent with feeds, which also use SITENAME as their "title".

As far as I see, your <http://giuliofidente.com/> site is configured so that the two are the same, but if AUTHOR and SITENAME is not the same, then this improves consistency, I believe. Perhaps this was even just typo? :-)

And thanks for the theme!