### PR TITLE
templates, base: allow hiding the use logo via HIDE_USER_LOGO

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Supports a number of common global variables but patches are welcomed if you nee
 
 - `ROUND_USER_LOGO` set this to `True` to crop your logo to a circle and add a black border
 
+- `HIDE_USER_LOGO` set this to `True` to hide the placeholder without adding your logo
+
 - `DISQUS_SITENAME` set this to your Disqus sitename to enable disqus comments in articles
 
 - `TAGLINE` some text rendered right below the logo

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,6 +36,7 @@
 <body>
   <aside>
     <div id="user_meta">
+      {% if not HIDE_USER_LOGO %}
       <a href="{{ SITEURL }}">
         {% if USER_LOGO_URL %}
         <img src="{{ USER_LOGO_URL }}" alt="logo"
@@ -44,6 +45,7 @@
         <img src="{{ SITEURL }}/theme/images/logo.png" alt="logo">
         {% endif %}
       </a>
+      {% endif %}
       <h2><a href="{{ SITEURL }}">{{ SITENAME }}</a></h2>
       <p>{{ TAGLINE }}</p>
       <ul>


### PR DESCRIPTION
This setting can be useful for users who want to bypass the placeholder,
but otherwise have no useful logo to display above SITENAME.

Default behavior is unchanged, of course.

(This is my 2nd out of 2 modifications I use for <https://vmiklos.hu/blog/>. :-) )