### PR TITLE
Add support for the quoteblock and attribution classes from the asciidoc backend

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -98,6 +98,19 @@ main article div.article_text blockquote {
   color: #999999;
   font-style: italic;
 }
+main article div.article_text div.quoteblock {
+  border-left: 5px solid #eeeeee;
+  color: #999999;
+  margin-bottom: 1.5em;
+  margin-left: 1em;
+  margin-right: 10%;
+  margin-top: 1em;
+  padding-left: 1em;
+}
+main article div.article_text div.quoteblock > div.attribution {
+  padding-top: 0.5em;
+  text-align: right;
+}
 main article div.gist {
   line-height: .875em;
 }

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -135,6 +135,21 @@ main {
         color: @med-grey;
         font-style: italic;
       }
+
+      // quoteblock and attribution are used by the asciidoc backend.
+      div.quoteblock {
+        border-left: 5px solid @light-grey;
+        color: @med-grey;
+        margin-bottom: 1.5em;
+        margin-left: 1.0em;
+        margin-right: 10%;
+        margin-top: 1.0em;
+        padding-left: 1.0em;
+      }
+      div.quoteblock > div.attribution {
+        padding-top: 0.5em;
+        text-align: right;
+      }
     }
 
     div.gist {


### PR DESCRIPTION
asciidoc reference which shows the expected rendering:

https://www.methods.co.nz/asciidoc/userguide.html#_quote_blocks

Do something similar, but reuse existing gray colors, don't reinvent new
ones.

Demo result: https://vmiklos.hu/blog/kasa.html (in Hungarian, but you get the idea :-) )