### PR TITLE
Add support for the readtime plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You can see the [theme in action](http://www.giuliofidente.com/).
 - syntax highlighting for pre blocks
 - supports google analytics
 - custom list of links
+- supports the [readtime](https://github.com/getpelican/pelican-plugins/tree/master/readtime) plugin
 
 ## KNOWN ISSUES
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -114,7 +114,7 @@ main article div.article_text div.quoteblock > div.attribution {
 main article div.gist {
   line-height: .875em;
 }
-main article div.article_meta {
+main article div.article_meta, div.article_readtime {
   font-size: .7rem;
   color: #999999;
 }

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -156,7 +156,7 @@ main {
       line-height: .875em;
     }
 
-    div.article_meta {
+    div.article_meta, div.article_readtime {
       font-size: .7rem;
       color: @med-grey;
     }

--- a/templates/article.html
+++ b/templates/article.html
@@ -10,6 +10,11 @@
   <div class="article_title">
     <h1><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
   </div>
+  {% if article.readtime %}
+  <div class="article_readtime">
+    <p>Estimated read time: {{article.readtime.minutes}} minutes</p>
+  </div>
+  {% endif %}
   <div class="article_text">
     {{ article.content }}
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,11 @@
   <div class="article_title">
     <h1><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
   </div>
+  {% if article.readtime %}
+  <div class="article_readtime">
+    <p>Estimated read time: {{article.readtime.minutes}} minutes</p>
+  </div>
+  {% endif %}
   <div class="article_text">
     {{ article.summary }}
   </div>


### PR DESCRIPTION
It could go to the end of articles, but that information is not too
relevant *after* reading the content.

See <https://github.com/getpelican/pelican-plugins/tree/master/readtime>
for the actual plugin.