### PR TITLE
templates: show meta of articles on the index page as well

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -10,6 +10,9 @@
   <div class="article_title">
     <h1><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
   </div>
+  <div class="article_meta">
+    <p>Posted on: {{ article.locale_date }}</p>
+  </div>
   {% if article.readtime %}
   <div class="article_readtime">
     <p>Estimated read time: {{article.readtime.minutes}} minutes</p>
@@ -19,7 +22,6 @@
     {{ article.content }}
   </div>
   <div class="article_meta">
-    <p>Posted on: {{ article.locale_date }}</p>
     <p>Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
       {% if article.tags %} &ndash; Tags:
       {% for tag in article.tags %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,16 @@
   <div class="article_text">
     {{ article.summary }}
   </div>
+  <div class="article_meta">
+    <p>Posted on: {{ article.locale_date }}</p>
+    <p>Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
+      {% if article.tags %} &ndash; Tags:
+      {% for tag in article.tags %}
+      <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %},{% endif %}
+      {% endfor %}
+      {% endif %}
+    </p>
+  </div>
 </article>
 {% if not loop.last %}
 <hr />

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,9 @@
   <div class="article_title">
     <h1><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
   </div>
+  <div class="article_meta">
+    <p>Posted on: {{ article.locale_date }}</p>
+  </div>
   {% if article.readtime %}
   <div class="article_readtime">
     <p>Estimated read time: {{article.readtime.minutes}} minutes</p>
@@ -12,16 +15,6 @@
   {% endif %}
   <div class="article_text">
     {{ article.summary }}
-  </div>
-  <div class="article_meta">
-    <p>Posted on: {{ article.locale_date }}</p>
-    <p>Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
-      {% if article.tags %} &ndash; Tags:
-      {% for tag in article.tags %}
-      <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %},{% endif %}
-      {% endfor %}
-      {% endif %}
-    </p>
   </div>
 </article>
 {% if not loop.last %}


### PR DESCRIPTION
In case readtime is configured, that is shown before the article content
on both the article and the index page.

The actual meta of an article (especially its date) is probably a much
more useful information, yet one had to navigate to the article page to
see it.

With this change, the readtime and meta is in sync, they are both shown
on the index and article pages in a consistent way.

Demo site where this is visible in action: https://vmiklos.hu/blog/ -- note the "Posted on" lines after the posts on the main page.