### PR TITLE
Add support for the imageblock class from the asciidoc backend

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -111,6 +111,11 @@ main article div.article_text div.quoteblock > div.attribution {
   padding-top: 0.5em;
   text-align: right;
 }
+main article div.article_text div.imageblock {
+  margin: 5px;
+  border: 1px solid #eeeeee;
+  padding: 5px;
+}
 main article div.gist {
   line-height: .875em;
 }

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -150,6 +150,13 @@ main {
         padding-top: 0.5em;
         text-align: right;
       }
+
+      // imageblock is used by the asciidoc backend.
+      div.imageblock {
+        margin: 5px;
+        border: 1px solid @light-grey;
+        padding: 5px;
+      }
     }
 
     div.gist {


### PR DESCRIPTION
This is very useful, otherwise in case you have multiple images in a
row, then the reader can be easily assume that caption N refers to image
N+1, not to image N. Adding a bit of margin, border and padding avoids
this confusion.

Example where this is visible in action: https://vmiklos.hu/blog/sw-continuous-endnotes.html

If you use the developer tools of your browser to disable the new css rule, you can see how the old confusing layout looked like.