### PR TITLE
templates: allow using matomo analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can see the [theme in action](http://www.giuliofidente.com/).
 
 - responsive
 - syntax highlighting for pre blocks
-- supports google analytics
+- supports google analytics and [matomo](https://matomo.org/)
 - custom list of links
 - supports the [readtime](https://github.com/getpelican/pelican-plugins/tree/master/readtime) plugin
 
@@ -30,6 +30,10 @@ Clone the [repository](https://github.com/gfidente/pelican-svbhack), edit your `
 Supports a number of common global variables but patches are welcomed if you need better support.
 
 - `GOOGLE_ANALYTICS` to use Google Analytics, set this var to your UA-XYZ code
+
+- `MATOMO_URL` to use Matomo, set this var to your server, e.g. "analytics.example.com" (no protocol prefix)
+
+- `MATOMO_SITE_ID` to use Matomo, set this var to your site ID, e.g. "1"
 
 - `USER_LOGO_URL` to replace the logo placeholder, put your logo in content/images/your_logo.png and make this var point to `SITEURL + '/static/images/your_logo.png'`
 

--- a/templates/modules/analytics.html
+++ b/templates/modules/analytics.html
@@ -11,3 +11,18 @@
   })();
 </script>
 {% endif %}
+{% if MATOMO_URL %}
+<script type="text/javascript">
+  var _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//{{ MATOMO_URL }}/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '{{ MATOMO_SITE_ID }}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+{% endif %}


### PR DESCRIPTION
Similar to Google Analytics, but something you can self-host.

The only difference is that you need to specify an URL as well, since you typically self-host Matomo.