### PR TITLE
Add support for the figure/figcaption elements from markdown-captions

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -116,6 +116,14 @@ main article div.article_text div.imageblock {
   border: 1px solid #eeeeee;
   padding: 5px;
 }
+main article div.article_text figure {
+  margin: 5px;
+  border: 1px solid #eeeeee;
+  padding: 5px;
+}
+main article div.article_text figcaption {
+  text-align: center;
+}
 main article div.gist {
   line-height: .875em;
 }

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -157,6 +157,16 @@ main {
         border: 1px solid @light-grey;
         padding: 5px;
       }
+
+      // figure and figcaption are used by the markdown_captions markdown extension.
+      figure {
+        margin: 5px;
+        border: 1px solid @light-grey;
+        padding: 5px;
+      }
+      figcaption {
+	text-align: center;
+      }
     }
 
     div.gist {


### PR DESCRIPTION
See <https://github.com/Evidlo/markdown_captions>, once the Python
module is installed, you can enable it for Pelican like this:

```
MARKDOWN = {
    'extension_configs': {
        ... other existing keys ...
        'markdown_captions': {},
    },
    ... other existing keys ...
}
```

Improve the output a little by centering the caption and drawing a
minimal border around the figure, similar to how it already looks like
with the asciidoc backend.