### PR TITLE
Add support for the headerlink class on <a> elements inside <hN>

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -124,6 +124,18 @@ main article div.article_text figure {
 main article div.article_text figcaption {
   text-align: center;
 }
+main article div.article_text h1 a.headerlink,
+main article div.article_text h2 a.headerlink,
+main article div.article_text h3 a.headerlink,
+main article div.article_text h4 a.headerlink {
+  visibility: hidden;
+}
+main article div.article_text h1:hover a.headerlink,
+main article div.article_text h2:hover a.headerlink,
+main article div.article_text h3:hover a.headerlink,
+main article div.article_text h4:hover a.headerlink {
+  visibility: visible;
+}
 main article div.gist {
   line-height: .875em;
 }

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -167,6 +167,17 @@ main {
       figcaption {
 	text-align: center;
       }
+
+      h1, h2, h3, h4 {
+        a.headerlink {
+	  visibility:hidden;
+        }
+      }
+      h1:hover, h2:hover, h3:hover, h4:hover {
+        a.headerlink {
+	  visibility:visible;
+        }
+      }
     }
 
     div.gist {


### PR DESCRIPTION
See the 'permalink' key in
<https://python-markdown.github.io/extensions/toc/#usage>, the idea is
that a CSS like:

h1 a{visibility:hidden;}
h1:hover a{visibility:visible;}

Can show a paragraph mark when hovering on h1, add these for the top few
heading elements.

<https://vmiklos.hu/blog/sw-content-controls3.html> is a demo of how this looks.