### PR TITLE
Add support for minimal border for tables

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -19,6 +19,15 @@ hr {
 img {
   max-width: 100%;
 }
+table {
+  border-collapse: collapse;
+}
+th,
+td {
+  padding: 4px;
+  border-width: thin;
+  border-style: solid;
+}
 .round-img {
   border-radius: 50%;
   padding: 2px;

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -41,6 +41,16 @@ img {
   max-width: 100%;
 }
 
+table {
+    border-collapse: collapse;
+}
+
+th, td {
+    padding: 4px;
+    border-width: thin;
+    border-style: solid;
+}
+
 .round-img {
   border-radius: 50%;
   padding: 2px;


### PR DESCRIPTION
Useful for markdown which has no borders by default. Based on what asciidoc does by default.

Sample output:

https://vmiklos.hu/blog/sw-zotero-plumbing.html