### PR TITLE
Integrate pelican series plugin with article template

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can see the [theme in action](http://www.giuliofidente.com/).
 - supports google analytics and [matomo](https://matomo.org/)
 - custom list of links
 - supports the [readtime](https://github.com/getpelican/pelican-plugins/tree/master/readtime) plugin
+- supports the [series](https://github.com/pelican-plugins/series) plugin
 
 ## KNOWN ISSUES
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -31,6 +31,18 @@
     </p>
   </div>
 
+  <!-- Pelican Series Plugin -->
+  {% if article.series %}
+  <p>This post is part {{ article.series.index }} of the "{{ article.series.name }}" series:</p>
+  <ol class="parts">
+      {% for part_article in article.series.all %}
+          <li {% if part_article == article %}class="active"{% endif %}>
+              <a href='{{ SITEURL }}/{{ part_article.url }}'>{{ part_article.title }}</a>
+          </li>
+      {% endfor %}
+  </ol>
+  {% endif %}
+
   {% if DISQUS_SITENAME %}
   <div id="article_comments">
     <div id="disqus_thread"></div>


### PR DESCRIPTION
Just a simple integration of the [Pelican Series](https://github.com/pelican-plugins/series) plugin with the article template. It can be enabled simply by using the `Series: Example Series` metadata (markdown format) in the source content.